### PR TITLE
Add unified Android app bridge and advanced Waydroid helper hooks to DroidDesk

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -1,0 +1,206 @@
+# DroidDesk
+
+Run a full Linux desktop on an Android phone. Not a terminal. Not an emulator. A real desktop environment with GPU acceleration, a proper app menu, and a workflow that now reaches into both the Linux side and the Android side of the phone.
+
+Plug the phone into a monitor and it behaves like a compact desktop machine. Unplug it and the full setup stays in your pocket.
+
+## Video
+
+[![Watch the video](https://img.youtube.com/vi/QCr4WWsfVv8/maxresdefault.jpg)](https://youtu.be/QCr4WWsfVv8)
+
+## What This Actually Runs
+
+Everything below has been tested and confirmed working on the Linux side:
+
+- **LibreOffice** for documents, spreadsheets, and presentations.
+- **VS Code** with Python, PIP, extensions, and normal desktop workflows.
+- **Claude Code** running directly in terminal inside DroidDesk.
+- **Blender** on mobile hardware. Heavy, but functional.
+- **Wireshark** for packet inspection and network analysis.
+- **Metasploit** for security and research workflows.
+- **Local AI** for offline LLM inference without an API.
+
+The new Android integration layer also lets DroidDesk index installed Android apps and expose launchers for them inside the Linux desktop menu. On phones and ROMs that support freeform windows or strong external-display multitasking, that gets very close to a true mixed Android + Linux desk setup. On standard Android builds, it still removes the friction of bouncing back through the launcher every time you need a phone app.
+
+## What Changed
+
+- **Android App Bridge** scans installed Android apps and adds launchers directly into DroidDesk.
+- **APK handoff** lets you trigger Android APK installation from Termux with a single command.
+- **Automatic refresh** runs when the desktop starts so new Android apps can appear in the menu without manual cleanup.
+- **Waydroid helper hook** is included for advanced users running a compatible rooted/kernel-capable environment where Waydroid is already installed separately.
+
+## How It Works
+
+The Linux environment runs through Termux with direct access to the phone's kernel. No emulation, no VM, and no translation layer for the Linux desktop itself.
+
+The setup script installs a full desktop environment inside Termux using the X11 and TUR repositories. For heavier packages that are not available natively in Termux, DroidDesk provisions a Proot container and then mirrors those Linux applications back into the desktop menu with the built-in App Bridge.
+
+The new Android App Bridge does the same kind of thing for the phone side. It scans installed Android packages, resolves their launcher activities, and creates desktop entries so they can be started from inside DroidDesk.
+
+For advanced users experimenting beyond stock rootless Termux, a `start-waydroid.sh` helper is also generated. That helper is intentionally separate from the main install path because Waydroid needs a compatible Linux base plus binder/memfd-capable kernel support and is not something DroidDesk can honestly promise on every standard Android phone.
+
+## Requirements
+
+- Any Android phone with ARM64 support
+- [Termux](https://f-droid.org/en/packages/com.termux/) from F-Droid
+- [Termux-X11](https://github.com/termux/termux-x11/releases/tag/nightly) for on-phone display
+
+### For Monitor Output (Optional)
+
+**Option A: USB-C display output**
+
+If your phone supports display output over USB-C, use a USB-C to HDMI adapter.
+
+**Option B: Raspberry Pi bridge**
+
+For phones without display output, you can use a Raspberry Pi Zero 2W as a bridge:
+
+- Raspberry Pi Zero 2W with Raspberry Pi OS
+- Micro USB to USB-C cable
+- USB-C hub
+- Micro HDMI to HDMI adapter
+- SD card with Pi firmware
+- Wireless keyboard and mouse
+
+The Pi connects through USB tethering, detects the phone automatically, and opens a fullscreen VNC session on the monitor.
+
+## Installation
+
+### Step 1: Install Termux
+
+Install Termux from F-Droid:
+
+https://f-droid.org/en/packages/com.termux/
+
+Do not use the Play Store build.
+
+### Step 2: Install Termux-X11
+
+Download the latest APK from:
+
+https://github.com/termux/termux-x11/releases/tag/nightly
+
+Install it on the phone. This is the display server used by DroidDesk.
+
+### Step 3: Run the Setup Script
+
+Open Termux and run:
+
+```bash
+curl -sL https://raw.githubusercontent.com/orailnoor/DroidDesk/main/termux-linux-setup.sh -o setup.sh
+bash setup.sh
+```
+
+The script will:
+
+1. Update Termux packages
+2. Add the X11 and TUR repositories
+3. Install your desktop environment
+4. Configure GPU acceleration
+5. Install Firefox, Git, Python, and core tools
+6. Set up a Proot Linux container
+7. Sync Proot Linux apps into the desktop menu
+8. Build the Android App Bridge and scan installed Android apps
+9. Apply the desktop theme and shortcuts
+10. Optionally set up VNC for remote or bridge use
+
+### Step 4: Start the Desktop
+
+After installation:
+
+```bash
+bash ~/start-x11.sh
+```
+
+Then open the Termux-X11 app on the phone.
+
+### Step 5: Install Linux Apps Inside Proot
+
+For packages that are not in TUR:
+
+```bash
+bash ~/start-proot.sh
+apt install wireshark
+exit
+bash ~/proot-menu-sync.sh
+```
+
+The Linux app will appear in the desktop menu.
+
+### Step 6: Refresh Android App Launchers
+
+If you install a new Android app and want to refresh the DroidDesk menu immediately:
+
+```bash
+bash ~/android-app-sync.sh
+```
+
+## Raspberry Pi Monitor Bridge Setup
+
+If you are using a Raspberry Pi Zero 2W for monitor output:
+
+### Step 1: Flash Raspberry Pi OS
+
+Flash a standard Raspberry Pi OS image and boot the Pi.
+
+### Step 2: Install VNC Viewer on the Pi
+
+```bash
+sudo apt update
+sudo apt install realvnc-vnc-viewer
+```
+
+### Step 3: Copy the Launcher Script
+
+```bash
+curl -sL https://raw.githubusercontent.com/orailnoor/DroidDesk/main/pi-launch_phone.sh -o ~/pi-launch_phone.sh
+chmod +x ~/pi-launch_phone.sh
+```
+
+### Step 4: Connect and Launch
+
+1. Connect the phone to the Pi by USB
+2. Enable USB tethering on the phone
+3. Start VNC on the phone with `bash ~/start-vnc.sh`
+4. Run the bridge script on the Pi:
+
+```bash
+bash ~/pi-launch_phone.sh
+```
+
+The Pi will detect the phone IP and open the VNC desktop in fullscreen.
+
+## Commands Reference
+
+| Command | What It Does |
+|---|---|
+| `bash ~/start-x11.sh` | Start DroidDesk through Termux-X11 |
+| `bash ~/start-vnc.sh` | Start DroidDesk through VNC |
+| `bash ~/start-proot.sh` | Open the Proot Linux shell |
+| `bash ~/proot-menu-sync.sh` | Refresh Linux app launchers from Proot |
+| `bash ~/android-app-sync.sh` | Refresh Android app launchers from the phone side |
+| `bash ~/install-android-apk.sh /path/to/app.apk` | Hand an APK to Android's package installer |
+| `bash ~/start-waydroid.sh` | Launch the advanced Waydroid helper if Waydroid is already installed separately |
+| `bash ~/stop-linux.sh` | Stop active desktop services |
+
+## Notes
+
+> [!WARNING]
+> **Disable aggressive child-process restrictions**
+> On some Android builds, the OS may kill Termux background processes and break long-running desktop sessions. If that happens, check Developer Options and disable the child-process restriction affecting Termux.
+
+- Termux-X11 on the phone is faster than VNC. Use VNC mainly for Pi bridge output or remote access.
+- The Proot container shares the same display as the native Termux desktop, so Linux apps launched through the bridge appear in the same environment.
+- The Android App Bridge launches the phone's native Android apps. On standard Android builds, those apps may come forward outside the Termux-X11 window. On devices with better desktop-mode or freeform-window support, the mixed workflow feels much more seamless.
+- GPU acceleration is strongest on Adreno-based phones. Other GPUs fall back to slower rendering paths.
+- The included `start-waydroid.sh` helper is for advanced compatible environments only. Stock rootless Termux users should treat the Android App Bridge as the supported Android integration path.
+
+## Credits
+
+Created by [orailnoor](https://youtube.com/@orailnoor)
+
+Android integration update by [Samin Yeasar](https://github.com/solez-ai), who pushed the mixed Android + Linux workflow forward with the Android app bridge direction, launcher sync improvements, and the advanced Waydroid-ready helper entry point.
+
+- Instagram: [solez_ai](https://www.instagram.com/solez_ai/)
+- GitHub: [solez-ai](https://github.com/solez-ai)
+- X: [Solez_None](https://x.com/Solez_None)

--- a/pi-launch_phone.sh
+++ b/pi-launch_phone.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# ========================================================
+# RPI DISPLAY BRIDGE: AUTO-CONNECT SCRIPT
+# This script detects the phone via USB and launches VNC
+# ========================================================
+
+echo "Starting Phone Display Bridge..."
+
+# 1. Loop until the phone is detected (max 30 seconds)
+MAX_RETRIES=30
+RETRY_COUNT=0
+PHONE_IP=""
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    # Find the Gateway IP from the routing table
+    PHONE_IP=$(ip route | grep default | awk '{print $3}' | head -n 1)
+    
+    if [ -n "$PHONE_IP" ]; then
+        echo "[+] Phone detected at IP: $PHONE_IP"
+        break
+    else
+        echo "[-] Waiting for USB Tethering... ($((MAX_RETRIES - RETRY_COUNT))s)"
+        sleep 1
+        RETRY_COUNT=$((RETRY_COUNT + 1))
+    fi
+done
+
+# 2. Final check and Launch
+if [ -n "$PHONE_IP" ]; then
+    echo "[+] Launching VNC Desktop in FullScreen..."
+    
+    # Optimization Flags for Pi Zero W Performance:
+    # -FullScreen: No window borders
+    # -QualityLevel 4: Balance between speed and looks
+    # -CompressLevel 9: High compression to save Pi CPU
+    # -LowColorLevel 1: Use 16-bit color for 2x faster rendering
+    
+    vncviewer $PHONE_IP::5901 \
+        -FullScreen \
+        -QualityLevel 4 \
+        -CompressLevel 9 \
+        -LowColorLevel 1 \
+        -MenuKey=F8
+else
+    echo "[!] ERROR: No phone detected via USB."
+    echo "[!] Make sure 'USB Tethering' is ON in your phone settings."
+    sleep 5
+fi

--- a/termux-linux-setup.sh
+++ b/termux-linux-setup.sh
@@ -1,0 +1,1310 @@
+#!/data/data/com.termux/files/usr/bin/bash
+#######################################################
+#  Termux Linux Setup Script
+#
+#  Features:
+#  - XFCE4 / LXQt / MATE / KDE Desktop
+#  - Smart GPU acceleration (Turnip/Zink)
+#  - Termux-X11 display + optional VNC
+#  - Modern dark XFCE theme + auto wallpaper
+#  - Proot Linux container (Ubuntu/Debian/Kali)
+#  - Proot App Bridge (apt installs appear in XFCE menu)
+#  - Android App Bridge (native phone apps appear in desktop menus)
+#  - Waydroid helper hooks for compatible advanced setups
+#  - Python & Web Dev environment
+#######################################################
+
+# ============== CONFIGURATION ==============
+TOTAL_STEPS=13
+CURRENT_STEP=0
+DE_CHOICE="1"
+DE_NAME="XFCE4"
+VNC_ENABLED=false
+SETUP_USERNAME="user"
+
+# Wallpaper URL — Ubuntu 4K wallpaper (set by user)
+WALLPAPER_URL="https://wallpapercave.com/download/ubuntu-4k-wallpapers-wp8303186"
+
+# ============== COLORS ==============
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+WHITE='\033[1;37m'
+GRAY='\033[0;90m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+# ============== PROGRESS FUNCTIONS ==============
+update_progress() {
+    CURRENT_STEP=$((CURRENT_STEP + 1))
+    PERCENT=$((CURRENT_STEP * 100 / TOTAL_STEPS))
+    FILLED=$((PERCENT / 5))
+    EMPTY=$((20 - FILLED))
+    BAR="${GREEN}"
+    for ((i=0; i<FILLED; i++)); do BAR+="*"; done
+    BAR+="${GRAY}"
+    for ((i=0; i<EMPTY; i++)); do BAR+="-"; done
+    BAR+="${NC}"
+    echo ""
+    echo -e "${WHITE}------------------------------------------------------------${NC}"
+    echo -e "${CYAN}  PROGRESS: ${WHITE}Step ${CURRENT_STEP}/${TOTAL_STEPS}${NC} ${BAR} ${WHITE}${PERCENT}%${NC}"
+    echo -e "${WHITE}------------------------------------------------------------${NC}"
+    echo ""
+}
+
+spinner() {
+    local pid=$1
+    local message=$2
+    local spin='-\|/'
+    local i=0
+    while kill -0 $pid 2>/dev/null; do
+        i=$(( (i+1) % 4 ))
+        printf "\r  [*] ${message} ${CYAN}${spin:$i:1}${NC}  "
+        sleep 0.1
+    done
+    wait $pid
+    local exit_code=$?
+    if [ $exit_code -eq 0 ]; then
+        printf "\r  [+] ${message}                    \n"
+    else
+        printf "\r  [-] ${message} ${RED}(failed)${NC}     \n"
+    fi
+    return $exit_code
+}
+
+install_pkg() {
+    local pkg=$1
+    local name=${2:-$pkg}
+    (DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        -o Dpkg::Options::="--force-confold" $pkg > /dev/null 2>&1) &
+    spinner $! "Installing ${name}..."
+}
+
+# ============== BANNER ==============
+show_banner() {
+    clear
+    echo -e "${CYAN}"
+    cat << 'BANNER'
+    ╔══════════════════════════════════════════╗
+    ║                                          ║
+    ║       Termux Linux Setup Script          ║
+    ║       X11 + Proot + Modern XFCE          ║
+    ║                                          ║
+    ╚══════════════════════════════════════════╝
+BANNER
+    echo -e "${NC}"
+    echo ""
+}
+
+# ============== DEVICE & DE SELECTION ==============
+setup_environment() {
+    echo -e "${PURPLE}[*] Detecting your device...${NC}"
+    echo ""
+
+    DEVICE_MODEL=$(getprop ro.product.model 2>/dev/null || echo "Unknown")
+    DEVICE_BRAND=$(getprop ro.product.brand 2>/dev/null || echo "Unknown")
+    ANDROID_VERSION=$(getprop ro.build.version.release 2>/dev/null || echo "Unknown")
+    CPU_ABI=$(getprop ro.product.cpu.abi 2>/dev/null || echo "arm64-v8a")
+    GPU_VENDOR=$(getprop ro.hardware.egl 2>/dev/null || echo "")
+
+    echo -e "  [*] Device : ${WHITE}${DEVICE_BRAND} ${DEVICE_MODEL}${NC}"
+    echo -e "  [*] Android: ${WHITE}${ANDROID_VERSION}${NC}"
+
+    if [[ "$GPU_VENDOR" == *"adreno"* ]] || \
+       [[ "$DEVICE_BRAND" =~ [Ss]amsung|[Oo]ne[Pp]lus|[Xx]iaomi|[Rr]edmi|[Pp]oco|[Mm]oto|motorola ]]; then
+        GPU_DRIVER="freedreno"
+        echo -e "  [*] GPU    : ${WHITE}Adreno — Hardware Acceleration Enabled${NC}"
+    else
+        GPU_DRIVER="zink_native"
+        echo -e "  [*] GPU    : ${WHITE}Non-Adreno — Zink/LLVMpipe fallback${NC}"
+        echo -e "${YELLOW}      [!] Recommend XFCE or LXQt for best performance.${NC}"
+    fi
+    echo ""
+
+    echo -e "${CYAN}Choose your Desktop Environment:${NC}"
+    echo -e "  ${WHITE}1) XFCE4${NC}      — Fast, customizable (Recommended)"
+    echo -e "  ${WHITE}2) LXQt${NC}       — Ultra lightweight"
+    echo -e "  ${WHITE}3) MATE${NC}       — Classic, moderate weight"
+    echo -e "  ${WHITE}4) KDE Plasma${NC} — Heavy, modern (needs strong GPU/RAM)"
+    echo ""
+    while true; do
+        read -p "Enter number (1-4) [default: 1]: " DE_INPUT
+        DE_INPUT=${DE_INPUT:-1}
+        if [[ "$DE_INPUT" =~ ^[1-4]$ ]]; then
+            DE_CHOICE="$DE_INPUT"; break
+        else
+            echo "Please enter 1, 2, 3, or 4."
+        fi
+    done
+
+    case $DE_CHOICE in
+        1) DE_NAME="XFCE4";;
+        2) DE_NAME="LXQt";;
+        3) DE_NAME="MATE";;
+        4) DE_NAME="KDE Plasma";;
+    esac
+
+    echo -e "\n${GREEN}[+] Selected: ${DE_NAME}${NC}"
+
+    # ---- Username ----
+    SETUP_USERNAME="root"
+    echo -e "  ${GREEN}[+] Proot User set to: ${SETUP_USERNAME} (Default)${NC}"
+    sleep 1
+}
+
+# ============== STEP 1: UPDATE ==============
+step_update() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Updating system packages...${NC}"
+    echo ""
+    (DEBIAN_FRONTEND=noninteractive apt-get update -y > /dev/null 2>&1) &
+    spinner $! "Updating package lists..."
+    (DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -q \
+        -o Dpkg::Options::="--force-confold" > /dev/null 2>&1) &
+    spinner $! "Upgrading installed packages..."
+}
+
+# ============== STEP 2: REPOSITORIES ==============
+step_repos() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Adding repositories...${NC}"
+    echo ""
+    install_pkg "x11-repo" "X11 Repository"
+    install_pkg "tur-repo" "TUR Repository"
+}
+
+# ============== STEP 3: TERMUX-X11 ==============
+step_x11() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Installing Termux-X11...${NC}"
+    echo ""
+    install_pkg "termux-x11-nightly" "Termux-X11 Display Server"
+    install_pkg "xorg-xrandr" "XRandR"
+}
+
+# ============== STEP 4: DESKTOP ==============
+step_desktop() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Installing ${DE_NAME}...${NC}"
+    echo ""
+
+    if [ "$DE_CHOICE" == "1" ]; then
+        install_pkg "xfce4" "XFCE4 Desktop"
+        install_pkg "xfce4-terminal" "XFCE4 Terminal"
+        install_pkg "xfce4-whiskermenu-plugin" "Whisker Menu"
+        install_pkg "xfce4-notifyd" "XFCE Notifications"
+        install_pkg "thunar" "Thunar File Manager"
+        install_pkg "mousepad" "Mousepad Editor"
+    elif [ "$DE_CHOICE" == "2" ]; then
+        install_pkg "lxqt" "LXQt Desktop"
+        install_pkg "qterminal" "QTerminal"
+        install_pkg "pcmanfm-qt" "PCManFM-Qt"
+        install_pkg "featherpad" "FeatherPad"
+    elif [ "$DE_CHOICE" == "3" ]; then
+        install_pkg "mate" "MATE Desktop"
+        install_pkg "mate-tweak" "MATE Tweak"
+        install_pkg "mate-terminal" "MATE Terminal"
+    elif [ "$DE_CHOICE" == "4" ]; then
+        install_pkg "plasma-desktop" "KDE Plasma"
+        install_pkg "konsole" "Konsole"
+        install_pkg "dolphin" "Dolphin"
+    fi
+}
+
+# ============== STEP 5: GPU DRIVERS ==============
+step_gpu() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Installing GPU Acceleration...${NC}"
+    echo ""
+    install_pkg "mesa-zink" "Mesa Zink Core"
+    if [ "$GPU_DRIVER" == "freedreno" ]; then
+        install_pkg "mesa-vulkan-icd-freedreno" "Turnip Adreno Driver"
+    fi
+    install_pkg "vulkan-loader-android" "Vulkan Loader"
+}
+
+# ============== STEP 6: AUDIO ==============
+step_audio() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Installing Audio...${NC}"
+    echo ""
+    install_pkg "pulseaudio" "PulseAudio"
+}
+
+# ============== STEP 7: APPS ==============
+step_apps() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Installing Apps...${NC}"
+    echo ""
+    install_pkg "firefox" "Firefox Browser"
+    install_pkg "git" "Git"
+    install_pkg "wget" "Wget"
+    install_pkg "curl" "cURL"
+    install_pkg "imagemagick" "ImageMagick (wallpaper)"
+}
+
+# ============== STEP 8: PYTHON ==============
+step_python() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Installing Python...${NC}"
+    echo ""
+    install_pkg "python" "Python 3"
+    install_pkg "python-pip" "pip"
+    echo -e "  [+] Python 3 installed"
+}
+
+# ============== STEP 9: PROOT ==============
+step_proot() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Setting up Proot Container...${NC}"
+    echo ""
+
+    install_pkg "proot-distro" "Proot-Distro Manager"
+    install_pkg "proot" "PRoot"
+
+    echo ""
+    echo -e "${CYAN}Choose a Linux distro for Proot:${NC}"
+    echo -e "  ${WHITE}1) Ubuntu 22.04 LTS${NC}  (Recommended)"
+    echo -e "  ${WHITE}2) Debian 12${NC}          (Minimal)"
+    echo -e "  ${WHITE}3) Kali Linux${NC}         (Security/Pentesting)"
+    echo ""
+    while true; do
+        read -p "Enter number (1-3) [default: 1]: " PROOT_INPUT
+        PROOT_INPUT=${PROOT_INPUT:-1}
+        if [[ "$PROOT_INPUT" =~ ^[1-3]$ ]]; then break; fi
+        echo "Please enter 1, 2, or 3."
+    done
+
+    case $PROOT_INPUT in
+        1) PROOT_DISTRO="ubuntu";         PROOT_LABEL="Ubuntu 22.04";;
+        2) PROOT_DISTRO="debian";         PROOT_LABEL="Debian 12";;
+        3) PROOT_DISTRO="kali-nethunter"; PROOT_LABEL="Kali Linux";;
+    esac
+
+    echo -e "\n${GREEN}[+] Installing ${PROOT_LABEL}...${NC}"
+    (proot-distro install "$PROOT_DISTRO" > /dev/null 2>&1) &
+    spinner $! "Downloading ${PROOT_LABEL} rootfs (may take a while)..."
+
+    echo -e "  [*] Bootstrapping ${PROOT_LABEL}..."
+    proot-distro login "$PROOT_DISTRO" -- bash -c "
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -y -q > /dev/null 2>&1
+        apt-get install -y -q --no-install-recommends \
+            mesa-utils vulkan-tools \
+            libgl1-mesa-glx libvulkan1 libgles2 \
+            xfce4 xfce4-terminal dbus-x11 \
+            sudo curl wget git htop nano > /dev/null 2>&1
+    " 2>/dev/null || true
+    echo -e "  [+] ${PROOT_LABEL} ready."
+
+    # ---- Create named user with working sudo ----
+    echo -e "  [*] Creating proot user: ${SETUP_USERNAME} (with sudo)..."
+    proot-distro login "$PROOT_DISTRO" -- bash -c "
+        # Create user if not exists
+        id '$SETUP_USERNAME' > /dev/null 2>&1 || \
+            useradd -m -s /bin/bash '$SETUP_USERNAME'
+
+        # Add to sudo group
+        usermod -aG sudo '$SETUP_USERNAME' 2>/dev/null || true
+
+        # Drop-in sudoers file (cleaner than editing /etc/sudoers directly)
+        # Defaults !requiretty  — allows sudo without a real terminal (proot)
+        # NOPASSWD            — no password prompt
+        mkdir -p /etc/sudoers.d
+        echo 'Defaults !requiretty' > /etc/sudoers.d/proot-compat
+        echo '$SETUP_USERNAME ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/proot-compat
+        chmod 0440 /etc/sudoers.d/proot-compat
+
+        # Ensure sudo binary has correct permissions (SETUID)
+        chmod u+s /usr/bin/sudo 2>/dev/null || true
+
+        # Nice coloured shell prompt
+        echo 'export PS1="\[\033[01;32m\]${SETUP_USERNAME}@linux\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' \
+            >> /home/'$SETUP_USERNAME'/.bashrc
+        # Useful aliases
+        echo 'alias ll="ls -la"' >> /home/'$SETUP_USERNAME'/.bashrc
+        echo 'alias update="sudo apt update && sudo apt upgrade -y"' >> /home/'$SETUP_USERNAME'/.bashrc
+    " 2>/dev/null || true
+    echo -e "  [+] Proot user '${SETUP_USERNAME}' created with passwordless sudo"
+
+    PROOT_BIN="/data/data/com.termux/files/usr/bin/proot-distro"
+    TERMUX_VK_ICD="/data/data/com.termux/files/usr/share/vulkan/icd.d"
+    TERMUX_LIB="/data/data/com.termux/files/usr/lib"
+
+    # ---- start-proot.sh ----
+    cat > ~/start-proot.sh << PROOTEOF
+#!/data/data/com.termux/files/usr/bin/bash
+PROOT_DISTRO="$PROOT_DISTRO"
+PROOT_LABEL="$PROOT_LABEL"
+TERMUX_TMP="\${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+
+echo ""
+echo "============================================="
+echo "  [*] Starting \$PROOT_LABEL"
+echo "============================================="
+echo ""
+
+BINDS=""
+[ -d "\$TERMUX_TMP/.X11-unix" ] && BINDS="\$BINDS --bind \$TERMUX_TMP/.X11-unix:/tmp/.X11-unix"
+[ -d "/dev/dri" ]               && BINDS="\$BINDS --bind /dev/dri:/dev/dri"
+[ -e "/dev/kgsl-3d0" ]          && BINDS="\$BINDS --bind /dev/kgsl-3d0:/dev/kgsl-3d0"
+[ -d "${TERMUX_VK_ICD}" ]       && BINDS="\$BINDS --bind ${TERMUX_VK_ICD}:/usr/share/vulkan/icd.d.termux"
+[ -f "${TERMUX_LIB}/libvulkan.so" ] && \
+    BINDS="\$BINDS --bind ${TERMUX_LIB}/libvulkan.so:/usr/lib/aarch64-linux-gnu/libvulkan_termux.so"
+
+_RC=\$(mktemp /data/data/com.termux/files/usr/tmp/proot_rc.XXXX)
+cat > "\$_RC" << 'RCEOF'
+export DISPLAY=:0
+export MESA_NO_ERROR=1
+export MESA_GL_VERSION_OVERRIDE=4.6
+export MESA_GLES_VERSION_OVERRIDE=3.2
+export GALLIUM_DRIVER=zink
+export MESA_LOADER_DRIVER_OVERRIDE=zink
+export TU_DEBUG=noconform
+export ZINK_DESCRIPTORS=lazy
+export MESA_VK_WSI_PRESENT_MODE=immediate
+[ -f /usr/share/vulkan/icd.d.termux/freedreno_icd.aarch64.json ] && \
+    export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d.termux/freedreno_icd.aarch64.json
+export XDG_DATA_DIRS=/usr/share:/usr/local/share:\${XDG_DATA_DIRS}
+export PS1="\[\033[01;32m\]$SETUP_USERNAME@linux\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "
+echo ""
+echo " User: $SETUP_USERNAME | GPU: GALLIUM=\${GALLIUM_DRIVER}"
+echo " Type 'exit' to leave proot."
+echo ""
+RCEOF
+
+proot-distro login "\$PROOT_DISTRO" \$BINDS --user root -- bash --rcfile "\$_RC"
+rm -f "\$_RC"
+PROOTEOF
+    chmod +x ~/start-proot.sh
+    echo -e "  [+] Created ~/start-proot.sh"
+
+    # ---- proot-menu-sync.sh (v3 — embedded) ----
+    cat > ~/proot-menu-sync.sh << 'SYNCEOF'
+#!/data/data/com.termux/files/usr/bin/bash
+# ============================================================
+#  Proot App Menu Bridge v3
+#  Syncs proot .desktop files into native XFCE menu.
+#  Fixes: $TMPDIR log path, runtime X11 bind, dbus-run-session,
+#         Blender libvulkan auto-detect, LibreOffice --norestore
+# ============================================================
+
+PROOT_DISTRO="${1:-ubuntu}"
+PROOT_BIN="/data/data/com.termux/files/usr/bin/proot-distro"
+PROOT_ROOTFS="/data/data/com.termux/files/usr/var/lib/proot-distro/installed-rootfs/$PROOT_DISTRO"
+PROOT_APPS="$PROOT_ROOTFS/usr/share/applications"
+BRIDGE_DIR="$HOME/.local/share/applications/proot-bridge"
+WRAPPER_DIR="$HOME/.local/share/proot-wrappers"
+TERMUX_TMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+
+if [ ! -f "$PROOT_BIN" ]; then
+    echo "[!] proot-distro not found. pkg install proot-distro"
+    exit 1
+fi
+if [ ! -d "$PROOT_ROOTFS" ]; then
+    echo "[!] Proot distro '$PROOT_DISTRO' not installed."
+    exit 1
+fi
+if [ ! -d "$PROOT_APPS" ]; then
+    echo "[!] No proot apps yet. proot-distro login $PROOT_DISTRO -- apt install <pkg>"
+    exit 0
+fi
+
+mkdir -p "$BRIDGE_DIR" "$WRAPPER_DIR"
+
+HAS_GPU="software"
+[ -d "/dev/dri" ] && HAS_GPU="zink"
+
+# Ensure dbus-x11 in proot
+if ! "$PROOT_BIN" login "$PROOT_DISTRO" -- which dbus-run-session > /dev/null 2>&1; then
+    echo "[*] Installing dbus-x11 in proot..."
+    "$PROOT_BIN" login "$PROOT_DISTRO" -- apt-get install -y -q dbus-x11 > /dev/null 2>&1
+fi
+
+SYNCED=0
+REMOVED=0
+
+for bridge_file in "$BRIDGE_DIR"/proot-*.desktop; do
+    [ -f "$bridge_file" ] || continue
+    original_name=$(basename "$bridge_file" | sed 's/^proot-//')
+    if [ ! -f "$PROOT_APPS/$original_name" ]; then
+        rm -f "$bridge_file" "$WRAPPER_DIR/proot-${original_name%.desktop}.sh"
+        REMOVED=$((REMOVED + 1))
+    fi
+done
+
+for desktop_file in "$PROOT_APPS"/*.desktop; do
+    [ -f "$desktop_file" ] || continue
+
+    filename=$(basename "$desktop_file")
+    appname="${filename%.desktop}"
+    output="$BRIDGE_DIR/proot-$filename"
+    wrapper="$WRAPPER_DIR/proot-${appname}.sh"
+
+    grep -q "^NoDisplay=true" "$desktop_file" 2>/dev/null && continue
+    grep -q "^Hidden=true"    "$desktop_file" 2>/dev/null && continue
+
+    ORIGINAL_EXEC=$(grep "^Exec=" "$desktop_file" | head -1 | sed 's/^Exec=//')
+    [ -z "$ORIGINAL_EXEC" ] && continue
+    CLEAN_EXEC=$(echo "$ORIGINAL_EXEC" | sed 's/ %[a-zA-Z]//g; s/%[a-zA-Z]//g')
+
+    APP_CMD="$CLEAN_EXEC"
+    EXTRA_ENV=""
+
+    echo "$appname" | grep -qi "libreoffice\|soffice" && \
+        APP_CMD="$CLEAN_EXEC --norestore --nofirststartwizard"
+
+    if echo "$appname" | grep -qi "blender"; then
+        APP_CMD="$CLEAN_EXEC"
+        if "$PROOT_BIN" login "$PROOT_DISTRO" -- \
+                ldconfig -p 2>/dev/null | grep -q "libvulkan.so.1"; then
+            EXTRA_ENV="export GALLIUM_DRIVER=zink; export MESA_GL_VERSION_OVERRIDE=4.6;"
+            echo "  [+] Blender: Zink GPU mode"
+        else
+            EXTRA_ENV="export LIBGL_ALWAYS_SOFTWARE=1; export GALLIUM_DRIVER=llvmpipe; export MESA_GL_VERSION_OVERRIDE=4.5;"
+            echo "  [!] Blender: Software mode (install libvulkan1 in proot for GPU)"
+        fi
+    fi
+
+    cat > "$wrapper" << WRAPEOF
+#!/data/data/com.termux/files/usr/bin/bash
+PROOT_BIN="$PROOT_BIN"
+PROOT_DISTRO="$PROOT_DISTRO"
+TERMUX_TMP="\${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+LOG="\$TERMUX_TMP/proot-${appname}.log"
+
+BINDS=""
+X11_DIR="\$TERMUX_TMP/.X11-unix"
+[ -d "\$X11_DIR" ]     && BINDS="\$BINDS --bind \$X11_DIR:/tmp/.X11-unix"
+[ -d "/dev/dri" ]      && BINDS="\$BINDS --bind /dev/dri:/dev/dri"
+[ -e "/dev/kgsl-3d0" ] && BINDS="\$BINDS --bind /dev/kgsl-3d0:/dev/kgsl-3d0"
+
+{
+echo "[+] Launching $appname at \$(date)"
+echo "    X11=\$X11_DIR  BINDS=\$BINDS"
+\$PROOT_BIN login "\$PROOT_DISTRO" \$BINDS -- /bin/bash -c "
+export DISPLAY=:0
+export XDG_RUNTIME_DIR=/tmp
+export MESA_NO_ERROR=1
+$EXTRA_ENV
+dbus-run-session $APP_CMD
+"
+EXIT_CODE=\$?
+echo "Exit: \$EXIT_CODE at \$(date)"
+} > "\$LOG" 2>&1
+
+[ \$EXIT_CODE -ne 0 ] && \
+    xfce4-terminal --title="$appname error" \
+        -e "bash -c 'cat \$LOG; echo; read -p \"Press Enter\"'" &
+WRAPEOF
+    chmod +x "$wrapper"
+
+    cp "$desktop_file" "$output"
+    sed -i \
+        -e "s|^Exec=.*|Exec=$wrapper|" \
+        -e "s|^TryExec=.*|TryExec=$wrapper|" \
+        -e '/^NoDisplay=/d' -e '/^Hidden=/d' \
+        "$output"
+    echo "NoDisplay=false" >> "$output"
+
+    APP_NAME=$(grep "^Name=" "$output" | head -1 | sed 's/^Name=//')
+    [[ "$APP_NAME" != \[P\]* ]] && sed -i "s|^Name=.*|Name=[P] $APP_NAME|" "$output"
+    SYNCED=$((SYNCED + 1))
+done
+
+echo "[+] Bridge: $SYNCED synced, $REMOVED removed."
+echo "    Logs: \$TERMUX_TMP/proot-<appname>.log"
+echo "    Re-run after new installs: bash ~/proot-menu-sync.sh"
+
+pgrep -x "xfce4-panel" > /dev/null 2>&1 && xfce4-panel --restart > /dev/null 2>&1 &
+pgrep -x "xfdesktop"   > /dev/null 2>&1 && { sleep 1; xfdesktop --reload > /dev/null 2>&1 & }
+SYNCEOF
+    chmod +x ~/proot-menu-sync.sh
+    echo -e "  [+] Created ~/proot-menu-sync.sh"
+
+    # Run once during install
+    bash ~/proot-menu-sync.sh "$PROOT_DISTRO" 2>/dev/null || true
+}
+
+# ============== STEP 10: ANDROID BRIDGE ==============
+step_android_bridge() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Configuring Android App Bridge...${NC}"
+    echo ""
+
+    mkdir -p ~/.local/share/android-bridge ~/.local/share/applications/android-bridge
+
+    cat > ~/.local/share/android-bridge/launch-android-app.sh << 'ANDROIDLAUNCHEOF'
+#!/data/data/com.termux/files/usr/bin/bash
+PKG="$1"
+COMPONENT="$2"
+
+if [ -z "$PKG" ]; then
+    echo "[!] Usage: launch-android-app.sh <package> [component]"
+    exit 1
+fi
+
+if [ -n "$COMPONENT" ] && command -v am > /dev/null 2>&1; then
+    am start --user 0 -n "$COMPONENT" > /dev/null 2>&1 && exit 0
+fi
+
+if command -v am > /dev/null 2>&1; then
+    am start --user 0 \
+        -a android.intent.action.MAIN \
+        -c android.intent.category.LAUNCHER \
+        -p "$PKG" > /dev/null 2>&1 && exit 0
+fi
+
+if command -v monkey > /dev/null 2>&1; then
+    monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 > /dev/null 2>&1 && exit 0
+fi
+
+echo "[!] Unable to launch $PKG from Termux."
+echo "    Make sure Android activity tools are available on this device."
+exit 1
+ANDROIDLAUNCHEOF
+    chmod +x ~/.local/share/android-bridge/launch-android-app.sh
+
+    cat > ~/install-android-apk.sh << 'APKINSTALLEOF'
+#!/data/data/com.termux/files/usr/bin/bash
+APK_PATH="$1"
+
+if [ -z "$APK_PATH" ]; then
+    echo "Usage: bash ~/install-android-apk.sh /path/to/app.apk"
+    exit 1
+fi
+
+if [ ! -f "$APK_PATH" ]; then
+    echo "[!] APK not found: $APK_PATH"
+    exit 1
+fi
+
+if command -v termux-open > /dev/null 2>&1; then
+    termux-open --content-type application/vnd.android.package-archive "$APK_PATH"
+    exit $?
+fi
+
+echo "[!] termux-open is not available. Install termux-tools or open the APK manually."
+exit 1
+APKINSTALLEOF
+    chmod +x ~/install-android-apk.sh
+
+    cat > ~/start-waydroid.sh << 'WAYDROIDEOF'
+#!/data/data/com.termux/files/usr/bin/bash
+echo ""
+echo "=============================================="
+echo "  [*] Starting Waydroid helper session..."
+echo "=============================================="
+echo ""
+
+if ! command -v waydroid > /dev/null 2>&1; then
+    echo "[!] Waydroid is not installed in this environment."
+    echo "    DroidDesk already runs on Android, so the built-in Android App Bridge"
+    echo "    is the supported path on standard Termux setups."
+    echo "    Use this helper only on advanced rooted/kernel-capable builds where"
+    echo "    Waydroid is already installed separately."
+    exit 1
+fi
+
+export DISPLAY=${DISPLAY:-:0}
+export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/tmp}
+
+waydroid container start
+waydroid session start > /dev/null 2>&1 &
+sleep 4
+waydroid prop set persist.waydroid.multi_windows true > /dev/null 2>&1 || true
+waydroid prop set persist.waydroid.width_padding 0 > /dev/null 2>&1 || true
+waydroid prop set persist.waydroid.height_padding 0 > /dev/null 2>&1 || true
+waydroid show-full-ui
+WAYDROIDEOF
+    chmod +x ~/start-waydroid.sh
+
+    cat > ~/android-app-sync.sh << 'ANDROIDSYNCEOF'
+#!/data/data/com.termux/files/usr/bin/bash
+BRIDGE_DIR="$HOME/.local/share/applications/android-bridge"
+WRAPPER_DIR="$HOME/.local/share/android-bridge"
+LAUNCHER="$WRAPPER_DIR/launch-android-app.sh"
+
+mkdir -p "$BRIDGE_DIR" "$WRAPPER_DIR"
+
+if [ ! -x "$LAUNCHER" ]; then
+    echo "[!] Android launcher helper is missing: $LAUNCHER"
+    exit 1
+fi
+
+for bridge_file in "$BRIDGE_DIR"/android-*.desktop; do
+    [ -f "$bridge_file" ] || continue
+    case "$(basename "$bridge_file")" in
+        android-refresh.desktop) continue ;;
+    esac
+    rm -f "$bridge_file"
+done
+
+if command -v cmd > /dev/null 2>&1; then
+    PACKAGE_LIST=$(cmd package list packages -3 2>/dev/null | sed 's/^package=//')
+else
+    PACKAGE_LIST=$(pm list packages -3 2>/dev/null | sed 's/^package=//')
+fi
+
+SYNCED=0
+
+for pkg in $PACKAGE_LIST; do
+    [ -n "$pkg" ] || continue
+
+    COMPONENT=""
+    if command -v cmd > /dev/null 2>&1; then
+        COMPONENT=$(cmd package resolve-activity --brief "$pkg" 2>/dev/null | tail -n 1 | tr -d '\r')
+        case "$COMPONENT" in
+            "No activity found"*) continue ;;
+        esac
+    fi
+
+    LABEL=$(dumpsys package "$pkg" 2>/dev/null | sed -n \
+        -e "s/.*application-label:'\\(.*\\)'.*/\\1/p" \
+        -e "s/.*application-label:\\(.*\\)$/\\1/p" | head -1)
+    [ -z "$LABEL" ] && LABEL=$(echo "$pkg" | awk -F. '{print $NF}')
+
+    SAFE_NAME=$(echo "$pkg" | tr '.:' '--')
+    DESKTOP_FILE="$BRIDGE_DIR/android-$SAFE_NAME.desktop"
+
+    cat > "$DESKTOP_FILE" << EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=[A] $LABEL
+Comment=Launch Android app $pkg
+Exec=$LAUNCHER $pkg $COMPONENT
+Icon=smartphone
+Categories=Utility;
+Terminal=false
+StartupNotify=false
+EOF
+
+    SYNCED=$((SYNCED + 1))
+done
+
+cat > "$BRIDGE_DIR/android-refresh.desktop" << EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=[A] Refresh Android Apps
+Comment=Rescan installed Android apps and refresh DroidDesk launchers
+Exec=bash $HOME/android-app-sync.sh
+Icon=view-refresh
+Categories=System;
+Terminal=false
+StartupNotify=false
+EOF
+
+chmod +x "$BRIDGE_DIR"/*.desktop 2>/dev/null
+
+pgrep -x "xfce4-panel" > /dev/null 2>&1 && xfce4-panel --restart > /dev/null 2>&1 &
+pgrep -x "xfdesktop" > /dev/null 2>&1 && { sleep 1; xfdesktop --reload > /dev/null 2>&1 & }
+
+echo "[+] Android bridge synced: $SYNCED apps"
+ANDROIDSYNCEOF
+    chmod +x ~/android-app-sync.sh
+
+    bash ~/android-app-sync.sh > /dev/null 2>&1 || true
+
+    echo -e "  [+] Created ~/android-app-sync.sh"
+    echo -e "  [+] Created ~/install-android-apk.sh"
+    echo -e "  [+] Created ~/start-waydroid.sh"
+}
+
+# ============== STEP 11: LAUNCHERS ==============
+step_launchers() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Creating Startup Scripts...${NC}"
+    echo ""
+
+    mkdir -p ~/.config ~/.vnc
+
+    # GPU env config
+    cat > ~/.config/linux-gpu.sh << EOF
+export MESA_NO_ERROR=1
+export MESA_GL_VERSION_OVERRIDE=4.6
+export MESA_GLES_VERSION_OVERRIDE=3.2
+export GALLIUM_DRIVER=zink
+export MESA_LOADER_DRIVER_OVERRIDE=zink
+export TU_DEBUG=noconform
+export MESA_VK_WSI_PRESENT_MODE=immediate
+export ZINK_DESCRIPTORS=lazy
+export XDG_DATA_DIRS=/data/data/com.termux/files/usr/share:\${XDG_DATA_DIRS}
+export XDG_CONFIG_DIRS=/data/data/com.termux/files/usr/etc/xdg:\${XDG_CONFIG_DIRS}
+EOF
+
+    if [ "$DE_CHOICE" == "4" ]; then
+        echo "export KWIN_COMPOSE=O2ES" >> ~/.config/linux-gpu.sh
+        mkdir -p ~/.config/plasma-workspace/env
+        cat > ~/.config/plasma-workspace/env/xdg_fix.sh << 'EOF'
+#!/data/data/com.termux/files/usr/bin/bash
+export XDG_DATA_DIRS=/data/data/com.termux/files/usr/share:${XDG_DATA_DIRS}
+export XDG_CONFIG_DIRS=/data/data/com.termux/files/usr/etc/xdg:${XDG_CONFIG_DIRS}
+EOF
+        chmod +x ~/.config/plasma-workspace/env/xdg_fix.sh
+    fi
+
+    case $DE_CHOICE in
+        1) EXEC_CMD="exec startxfce4"
+           KILL_CMD="pkill -9 xfce4-session 2>/dev/null";;
+        2) EXEC_CMD="exec startlxqt"
+           KILL_CMD="pkill -9 lxqt-session 2>/dev/null";;
+        3) EXEC_CMD="exec mate-session"
+           KILL_CMD="pkill -9 mate-session 2>/dev/null";;
+        4) EXEC_CMD="(sleep 5 && pkill -9 plasmashell && plasmashell) > /dev/null 2>&1 &
+exec startplasma-x11"
+           KILL_CMD="pkill -9 startplasma-x11 2>/dev/null; pkill -9 kwin_x11 2>/dev/null";;
+    esac
+
+    # ---- start-x11.sh ----
+    cat > ~/start-x11.sh << LAUNCHEREOF
+#!/data/data/com.termux/files/usr/bin/bash
+echo ""
+echo "=============================================="
+echo "  [*] Starting ${DE_NAME} via Termux-X11..."
+echo "=============================================="
+echo ""
+source ~/.config/linux-gpu.sh 2>/dev/null
+
+# Override Android's u0_a281 with the custom username
+# XFCE panel reads USER/LOGNAME for all user-facing displays
+export USER="$SETUP_USERNAME"
+export LOGNAME="$SETUP_USERNAME"
+export HOSTNAME="android-linux"
+export HOST="android-linux"
+
+pkill -9 -f "termux.x11" 2>/dev/null
+pkill -9 -f "Xvnc" 2>/dev/null
+${KILL_CMD}
+pkill -9 -f "dbus" 2>/dev/null
+
+unset PULSE_SERVER
+pulseaudio --kill 2>/dev/null
+sleep 0.5
+echo "[*] Starting audio..."
+pulseaudio --start --exit-idle-time=-1
+sleep 1
+pactl load-module module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1 2>/dev/null
+export PULSE_SERVER=127.0.0.1
+
+echo "[*] Starting Termux-X11 on :0..."
+termux-x11 :0 -ac &
+sleep 3
+export DISPLAY=:0
+
+# Sync proot apps into menu (background, non-blocking)
+[ -f ~/proot-menu-sync.sh ] && bash ~/proot-menu-sync.sh > /dev/null 2>&1 &
+[ -f ~/android-app-sync.sh ] && bash ~/android-app-sync.sh > /dev/null 2>&1 &
+
+echo "----------------------------------------------"
+echo "  [*] Open the Termux-X11 app to see desktop"
+echo "----------------------------------------------"
+echo ""
+${EXEC_CMD}
+LAUNCHEREOF
+    chmod +x ~/start-x11.sh
+    echo -e "  [+] Created ~/start-x11.sh"
+
+    # ---- stop-linux.sh ----
+    cat > ~/stop-linux.sh << STOPEOF
+#!/data/data/com.termux/files/usr/bin/bash
+echo "Stopping all sessions..."
+pkill -9 -f "termux.x11" 2>/dev/null
+vncserver -kill :1 2>/dev/null
+pkill -9 -f "Xvnc" 2>/dev/null
+pkill -9 -f "pulseaudio" 2>/dev/null
+${KILL_CMD}
+pkill -9 -f "dbus" 2>/dev/null
+command -v waydroid > /dev/null 2>&1 && waydroid session stop > /dev/null 2>&1
+rm -f /tmp/.X1-lock /tmp/.X11-unix/X1 2>/dev/null
+echo "Done."
+STOPEOF
+    chmod +x ~/stop-linux.sh
+    echo -e "  [+] Created ~/stop-linux.sh"
+}
+
+# ============== STEP 12: XFCE MODERN THEME ==============
+step_theme_xfce() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Configuring Modern XFCE Theme...${NC}"
+    echo ""
+
+    mkdir -p ~/.config/xfce4/xfconf/xfce-perchannel-xml \
+             ~/.config/autostart \
+             ~/.local/share/themes
+
+    # ---- GTK + Font settings (xsettings.xml) ----
+    cat > ~/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml << 'XSEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="xsettings" version="1.0">
+  <property name="Net" type="empty">
+    <property name="ThemeName" type="string" value="Adwaita-dark"/>
+    <property name="IconThemeName" type="string" value="Adwaita"/>
+  </property>
+  <property name="Xft" type="empty">
+    <property name="DPI" type="int" value="96"/>
+    <property name="Antialias" type="int" value="1"/>
+    <property name="Hinting" type="int" value="1"/>
+    <property name="HintStyle" type="string" value="hintslight"/>
+    <property name="RGBA" type="string" value="rgb"/>
+  </property>
+  <property name="Gtk" type="empty">
+    <property name="FontName" type="string" value="Sans 11"/>
+    <property name="MonospaceFontName" type="string" value="Monospace 10"/>
+    <property name="DecorationLayout" type="string" value="menu:minimize,maximize,close"/>
+    <property name="MenuImages" type="bool" value="true"/>
+    <property name="ButtonImages" type="bool" value="true"/>
+  </property>
+</channel>
+XSEOF
+
+    # ---- Window manager (xfwm4.xml) ----
+    cat > ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml << 'XWEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="xfwm4" version="1.0">
+  <property name="general" type="empty">
+    <property name="theme" type="string" value="Default-xhdpi"/>
+    <property name="title_font" type="string" value="Sans Bold 10"/>
+    <property name="use_compositing" type="bool" value="true"/>
+    <property name="frame_opacity" type="int" value="95"/>
+    <property name="inactive_opacity" type="int" value="90"/>
+    <property name="popup_opacity" type="int" value="95"/>
+    <property name="show_frame_shadow" type="bool" value="true"/>
+    <property name="show_popup_shadow" type="bool" value="true"/>
+    <property name="shadow_opacity" type="int" value="50"/>
+    <property name="button_layout" type="string" value="O|SHMC"/>
+    <property name="snap_to_windows" type="bool" value="true"/>
+    <property name="snap_to_border" type="bool" value="true"/>
+    <property name="tile_on_move" type="bool" value="true"/>
+    <property name="wrap_workspaces" type="bool" value="false"/>
+  </property>
+</channel>
+XWEOF
+
+    # ---- Terminal dark theme (Dracula) ----
+    mkdir -p ~/.config/xfce4
+    cat > ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-terminal.xml << 'TERMEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="xfce4-terminal" version="1.0">
+  <property name="color-foreground" type="string" value="#f8f8f2"/>
+  <property name="color-background" type="string" value="#282a36"/>
+  <property name="color-cursor" type="string" value="#f8f8f2"/>
+  <property name="color-selection" type="string" value="#44475a"/>
+  <property name="color-palette" type="string" value="#21222c;#ff5555;#50fa7b;#f1fa8c;#bd93f9;#ff79c6;#8be9fd;#f8f8f2;#6272a4;#ff6e6e;#69ff94;#ffffa5;#d6acff;#ff92df;#a4ffff;#ffffff"/>
+  <property name="font-name" type="string" value="Monospace 11"/>
+  <property name="misc-use-padding" type="bool" value="true"/>
+  <property name="misc-cursor-blinks" type="bool" value="true"/>
+  <property name="misc-cursor-shape" type="uint" value="1"/>
+  <property name="scrolling-bar" type="uint" value="0"/>
+  <property name="tab-activity-color" type="string" value="#bd93f9"/>
+  <property name="title-mode" type="uint" value="0"/>
+</channel>
+TERMEOF
+
+    # ---- Keyboard shortcuts ----
+    cat > ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml << 'KBEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="xfce4-keyboard-shortcuts" version="1.0">
+  <property name="commands" type="empty">
+    <property name="custom" type="empty">
+      <property name="&lt;Super&gt;e" type="string" value="thunar"/>
+      <property name="&lt;Super&gt;t" type="string" value="xfce4-terminal"/>
+      <property name="&lt;Super&gt;r" type="string" value="xfce4-appfinder --collapsed"/>
+      <property name="&lt;Alt&gt;F2" type="string" value="xfce4-appfinder --collapsed"/>
+      <property name="Print" type="string" value="xfce4-screenshooter"/>
+    </property>
+  </property>
+  <property name="xfwm4" type="empty">
+    <property name="custom" type="empty">
+      <property name="&lt;Alt&gt;F4" type="string" value="close_window_key"/>
+      <property name="&lt;Alt&gt;F10" type="string" value="maximize_window_key"/>
+      <property name="&lt;Super&gt;d" type="string" value="show_desktop_key"/>
+      <property name="&lt;Super&gt;Left" type="string" value="tile_left_key"/>
+      <property name="&lt;Super&gt;Right" type="string" value="tile_right_key"/>
+      <property name="&lt;Super&gt;Up" type="string" value="maximize_window_key"/>
+    </property>
+  </property>
+</channel>
+KBEOF
+
+    # ---- Desktop settings (icon layout, hide useless icons) ----
+    cat > ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml << 'DESKEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="xfce4-desktop" version="1.0">
+  <property name="desktop-icons" type="empty">
+    <property name="file-icons" type="empty">
+      <property name="show-filesystem" type="bool" value="false"/>
+      <property name="show-home" type="bool" value="true"/>
+      <property name="show-trash" type="bool" value="true"/>
+      <property name="show-removable" type="bool" value="true"/>
+    </property>
+    <property name="icon-size" type="uint" value="48"/>
+    <property name="tooltip-size" type="double" value="64"/>
+  </property>
+</channel>
+DESKEOF
+
+    # ---- First-run script (panel + wallpaper via xfconf-query) ----
+    # Runs once when XFCE starts for the first time
+    cat > ~/.config/xfce-first-run.sh << 'FREOF'
+#!/data/data/com.termux/files/usr/bin/bash
+# XFCE First Run: configure panel + wallpaper
+WALLPAPER="$HOME/.config/linux-wallpaper.jpg"
+
+sleep 4  # Wait for xfconfd + panel to be ready
+
+# ---- Dark Adwaita theme ----
+xfconf-query -c xsettings -p /Net/ThemeName -s "Adwaita-dark"
+xfconf-query -c xfwm4 -p /general/theme -s "Default-xhdpi"
+
+# ---- Panel: Move panel-1 to bottom, resize ----
+# Position: p=8 = bottom-center
+xfconf-query -c xfce4-panel -p /panels/panel-1/position -s "p=8;x=0;y=0" 2>/dev/null || true
+xfconf-query -c xfce4-panel -p /panels/panel-1/size -t int -s 44 2>/dev/null || true
+xfconf-query -c xfce4-panel -p /panels/panel-1/position-locked -s true 2>/dev/null || true
+xfconf-query -c xfce4-panel -p /panels/panel-1/background-style -t int -s 1 2>/dev/null || true
+xfconf-query -c xfce4-panel -p /panels/panel-1/background-rgba \
+    -t double -s 0.12 -t double -s 0.12 -t double -s 0.18 -t double -s 0.90 2>/dev/null || true
+
+# ---- Panel-2: reduce top panel size if it exists ----
+xfconf-query -c xfce4-panel -p /panels/panel-2/size -t int -s 28 2>/dev/null || true
+xfconf-query -c xfce4-panel -p /panels/panel-2/background-style -t int -s 1 2>/dev/null || true
+xfconf-query -c xfce4-panel -p /panels/panel-2/background-rgba \
+    -t double -s 0.10 -t double -s 0.10 -t double -s 0.14 -t double -s 0.95 2>/dev/null || true
+
+# ---- Wallpaper ----
+if [ -f "$WALLPAPER" ]; then
+    for prop in $(xfconf-query -c xfce4-desktop -lv 2>/dev/null | \
+                  grep "last-image" | awk '{print $1}'); do
+        xfconf-query -c xfce4-desktop -p "$prop" -s "$WALLPAPER" 2>/dev/null
+    done
+    # Set image style: 5 = zoomed/scaled
+    for prop in $(xfconf-query -c xfce4-desktop -lv 2>/dev/null | \
+                  grep "image-style" | awk '{print $1}'); do
+        xfconf-query -c xfce4-desktop -p "$prop" -t int -s 5 2>/dev/null
+    done
+    xfdesktop --reload 2>/dev/null &
+fi
+
+# ---- Compositing tuning ----
+xfconf-query -c xfwm4 -p /general/use_compositing -s true 2>/dev/null || true
+xfconf-query -c xfwm4 -p /general/frame_opacity -t int -s 95 2>/dev/null || true
+
+# ---- Remove this autostart so it never runs again ----
+rm -f "$HOME/.config/autostart/xfce-first-run.desktop"
+FREOF
+    chmod +x ~/.config/xfce-first-run.sh
+
+    # Register as XFCE autostart (one-shot)
+    cat > ~/.config/autostart/xfce-first-run.desktop << 'AREOF'
+[Desktop Entry]
+Type=Application
+Name=XFCE First Run Setup
+Exec=bash /root/.config/xfce-first-run.sh
+Hidden=false
+NoDisplay=true
+X-GNOME-Autostart-enabled=true
+AREOF
+
+    # ---- Wallpaper: URL → gradient fallback → skip ----
+    WALLPAPER_FILE="$HOME/.config/linux-wallpaper.jpg"
+    WALLPAPER_OK=false
+
+    if [ -n "$WALLPAPER_URL" ]; then
+        echo -e "  [*] Downloading wallpaper..."
+        # -L = follow redirects, --timeout = don't hang forever, -q = silent
+        (wget -L -q --timeout=30 --tries=2 \
+            -O "$WALLPAPER_FILE" "$WALLPAPER_URL" > /dev/null 2>&1) &
+        spinner $! "Downloading wallpaper (timeout: 30s)..."
+
+        # Validate: must exist AND be >10KB (not an error HTML page)
+        if [ -f "$WALLPAPER_FILE" ] && \
+           [ "$(wc -c < "$WALLPAPER_FILE" 2>/dev/null)" -gt 10240 ]; then
+            echo -e "  [+] Wallpaper downloaded OK"
+            WALLPAPER_OK=true
+        else
+            rm -f "$WALLPAPER_FILE"
+            echo -e "  [!] Wallpaper URL failed or returned invalid data — trying gradient..."
+        fi
+    fi
+
+    if [ "$WALLPAPER_OK" = false ]; then
+        # Fallback: generate dark gradient with ImageMagick
+        if command -v convert > /dev/null 2>&1; then
+            (convert -size 1920x1080 \
+                gradient:"#0f0c29"-"#302b63" \
+                "$WALLPAPER_FILE" > /dev/null 2>&1) &
+            spinner $! "Generating gradient wallpaper..."
+            [ -f "$WALLPAPER_FILE" ] && WALLPAPER_OK=true && \
+                echo -e "  [+] Gradient wallpaper generated"
+        fi
+    fi
+
+    if [ "$WALLPAPER_OK" = false ]; then
+        echo -e "  [!] Wallpaper skipped (URL failed + ImageMagick unavailable)"
+        echo -e "      Desktop will use XFCE default background."
+    fi
+
+    echo -e "  [+] XFCE dark theme configured (Adwaita-dark + Dracula terminal)"
+    echo -e "  [+] First-run script will configure panels on first launch"
+}
+
+# ============== STEP 13: SHORTCUTS ==============
+step_shortcuts() {
+    update_progress
+    echo -e "${PURPLE}[Step ${CURRENT_STEP}/${TOTAL_STEPS}] Creating Desktop Shortcuts...${NC}"
+    echo ""
+    mkdir -p ~/Desktop
+
+    cat > ~/Desktop/Firefox.desktop << 'EOF'
+[Desktop Entry]
+Name=Firefox
+Exec=firefox
+Icon=firefox
+Type=Application
+EOF
+
+    cat > ~/Desktop/Files.desktop << 'EOF'
+[Desktop Entry]
+Name=Files
+Exec=thunar
+Icon=folder
+Type=Application
+EOF
+
+    local term_cmd="xfce4-terminal"
+    [ "$DE_CHOICE" == "2" ] && term_cmd="qterminal"
+    [ "$DE_CHOICE" == "3" ] && term_cmd="mate-terminal"
+    [ "$DE_CHOICE" == "4" ] && term_cmd="konsole"
+
+    cat > ~/Desktop/Terminal.desktop << EOF
+[Desktop Entry]
+Name=Terminal
+Exec=${term_cmd}
+Icon=utilities-terminal
+Type=Application
+EOF
+
+    cat > ~/Desktop/Proot.desktop << EOF
+[Desktop Entry]
+Name=Linux Container
+Comment=Open Proot Shell with GPU support
+Exec=${term_cmd} -e "bash /root/start-proot.sh"
+Icon=system-run
+Type=Application
+Terminal=false
+EOF
+
+    cat > ~/Desktop/AndroidApps.desktop << EOF
+[Desktop Entry]
+Name=Android Apps
+Comment=Refresh Android app launchers from the phone side
+Exec=${term_cmd} -e "bash /root/android-app-sync.sh; echo; read -p 'Press Enter to close...'"
+Icon=smartphone
+Type=Application
+Terminal=false
+EOF
+
+    cat > ~/Desktop/Waydroid.desktop << EOF
+[Desktop Entry]
+Name=Waydroid Helper
+Comment=Launch Waydroid on compatible advanced setups
+Exec=${term_cmd} -e "bash /root/start-waydroid.sh; echo; read -p 'Press Enter to close...'"
+Icon=applications-system
+Type=Application
+Terminal=false
+EOF
+
+    chmod +x ~/Desktop/*.desktop 2>/dev/null
+    echo -e "  [+] Shortcuts: Firefox, Files, Terminal, Proot, Android Apps, Waydroid Helper"
+}
+
+# ============== VNC (OPTIONAL — asked at end) ==============
+step_vnc_optional() {
+    echo ""
+    echo -e "${YELLOW}============================================================${NC}"
+    echo -e "${WHITE}  OPTIONAL: VNC Remote Desktop${NC}"
+    echo -e "${YELLOW}============================================================${NC}"
+    echo ""
+    echo -e "  VNC lets you connect from another device (phone, PC, tablet)"
+    echo -e "  using any VNC Viewer app over WiFi or USB."
+    echo ""
+    read -p "  Install VNC support? (y/N): " VNC_ANSWER
+    VNC_ANSWER=${VNC_ANSWER:-N}
+
+    if [[ "$VNC_ANSWER" =~ ^[Yy]$ ]]; then
+        VNC_ENABLED=true
+
+        read -p "  VNC password [default: 123456]: " VNC_PASS_IN
+        VNC_PASS="${VNC_PASS_IN:-123456}"
+        read -p "  Resolution [default: 1280x720]: " VNC_GEO_IN
+        VNC_GEOMETRY="${VNC_GEO_IN:-1280x720}"
+        VNC_DISPLAY=":1"
+
+        echo ""
+        echo -e "  [*] Installing TigerVNC..."
+        install_pkg "tigervnc" "TigerVNC Server"
+
+        mkdir -p ~/.vnc
+        echo "$VNC_PASS" | vncpasswd -f > ~/.vnc/passwd
+        chmod 600 ~/.vnc/passwd
+
+        case $DE_CHOICE in
+            1) VNC_EXEC="exec startxfce4";;
+            2) VNC_EXEC="exec startlxqt";;
+            3) VNC_EXEC="exec mate-session";;
+            4) VNC_EXEC="exec startplasma-x11";;
+        esac
+
+        cat > ~/.vnc/xstartup << VNCSTARTUP
+#!/data/data/com.termux/files/usr/bin/bash
+export MESA_NO_ERROR=1
+export MESA_GL_VERSION_OVERRIDE=4.6
+export MESA_GLES_VERSION_OVERRIDE=3.2
+export GALLIUM_DRIVER=zink
+export MESA_LOADER_DRIVER_OVERRIDE=zink
+export TU_DEBUG=noconform
+export ZINK_DESCRIPTORS=lazy
+export XDG_DATA_DIRS=/data/data/com.termux/files/usr/share:\${XDG_DATA_DIRS}
+export XDG_CONFIG_DIRS=/data/data/com.termux/files/usr/etc/xdg:\${XDG_CONFIG_DIRS}
+$VNC_EXEC
+VNCSTARTUP
+        chmod +x ~/.vnc/xstartup
+
+        cat > ~/start-vnc.sh << VNCEOF
+#!/data/data/com.termux/files/usr/bin/bash
+echo ""
+echo "=============================================="
+echo "  [*] Starting ${DE_NAME} via TigerVNC..."
+echo "=============================================="
+echo ""
+
+pkill -9 -f "termux.x11" 2>/dev/null
+vncserver -kill ${VNC_DISPLAY} 2>/dev/null
+rm -f /tmp/.X1-lock /tmp/.X11-unix/X1 2>/dev/null
+
+unset PULSE_SERVER
+pulseaudio --kill 2>/dev/null
+sleep 0.5
+pulseaudio --start --exit-idle-time=-1
+sleep 1
+pactl load-module module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1 2>/dev/null
+export PULSE_SERVER=127.0.0.1
+
+vncserver -localhost no -geometry ${VNC_GEOMETRY} -depth 24 ${VNC_DISPLAY}
+
+DEVICE_IP=\$(ip -4 addr show wlan0 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -1)
+echo ""
+echo "=============================================="
+echo "  VNC Ready! Connect with any VNC Viewer:"
+echo "    Local   : 127.0.0.1:5901"
+[ -n "\$DEVICE_IP" ] && echo "    Network : \${DEVICE_IP}:5901"
+echo "    Password: ${VNC_PASS}"
+echo "=============================================="
+VNCEOF
+        chmod +x ~/start-vnc.sh
+        echo -e "  [+] Created ~/start-vnc.sh"
+    else
+        echo -e "  [*] Skipping VNC. You can add it later with:"
+        echo -e "      pkg install tigervnc"
+    fi
+}
+
+# ============== COMPLETION ==============
+show_completion() {
+    echo ""
+    echo -e "${GREEN}"
+    cat << 'COMPLETE'
+    ╔══════════════════════════════════════════╗
+    ║       INSTALLATION COMPLETE!             ║
+    ╚══════════════════════════════════════════╝
+COMPLETE
+    echo -e "${NC}"
+
+    echo -e "${WHITE}[*] ${DE_NAME} desktop is ready.${NC}"
+    echo ""
+    echo -e "${CYAN}[*] Installed:${NC}"
+    echo "    - Firefox, Git, Python 3"
+    echo "    - GPU Acceleration (Turnip/Zink)"
+    echo "    - Proot Linux Container + App Bridge"
+    echo "    - Android App Bridge for native phone apps"
+    echo "    - Modern Dark XFCE Theme (Adwaita + Dracula terminal)"
+    echo ""
+    echo -e "${YELLOW}============================================================${NC}"
+    echo -e "${WHITE}  HOW TO START:${NC}"
+    echo -e "${YELLOW}============================================================${NC}"
+    echo ""
+    echo -e "  ${GREEN}Native X11 (recommended):${NC}"
+    echo -e "    ${WHITE}bash ~/start-x11.sh${NC}"
+    echo -e "    Then open the ${WHITE}Termux-X11${NC} app"
+    echo ""
+    if [ "$VNC_ENABLED" = "true" ]; then
+        echo -e "  ${GREEN}VNC (connect via any VNC Viewer):${NC}"
+        echo -e "    ${WHITE}bash ~/start-vnc.sh${NC}  → 127.0.0.1:5901"
+        echo ""
+    fi
+    echo -e "  ${GREEN}Proot Linux shell:${NC}"
+    echo -e "    ${WHITE}bash ~/start-proot.sh${NC}"
+    echo ""
+    echo -e "  ${GREEN}Install proot app → sync to XFCE menu:${NC}"
+    echo -e "    ${WHITE}bash ~/proot-menu-sync.sh${NC}"
+    echo ""
+    echo -e "  ${GREEN}Refresh Android apps in the desktop menu:${NC}"
+    echo -e "    ${WHITE}bash ~/android-app-sync.sh${NC}"
+    echo ""
+    echo -e "  ${GREEN}Install an Android APK from Termux:${NC}"
+    echo -e "    ${WHITE}bash ~/install-android-apk.sh /path/to/app.apk${NC}"
+    echo ""
+    echo -e "  ${GREEN}Advanced Waydroid helper (only if you installed Waydroid separately):${NC}"
+    echo -e "    ${WHITE}bash ~/start-waydroid.sh${NC}"
+    echo ""
+    echo -e "  ${GREEN}Stop everything:${NC}"
+    echo -e "    ${WHITE}bash ~/stop-linux.sh${NC}"
+    echo ""
+    echo -e "${YELLOW}============================================================${NC}"
+    echo ""
+    echo -e "${CYAN}  👤 Your username : ${WHITE}${SETUP_USERNAME}${NC}"
+    echo ""
+    echo -e "${YELLOW}  ★━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━★${NC}"
+    echo -e "${WHITE}     If you found this helpful, please subscribe to:${NC}"
+    echo -e "${RED}           ▶  orailnoor  on YouTube  ◀${NC}"
+    echo -e "${YELLOW}  ★━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━★${NC}"
+    echo ""
+}
+
+# ============== MAIN ==============
+main() {
+    show_banner
+    setup_environment
+
+    step_update
+    step_repos
+    step_x11
+    step_desktop
+    step_gpu
+    step_audio
+    step_apps
+    step_python
+    step_proot
+    step_android_bridge
+    step_launchers
+    step_theme_xfce
+    step_shortcuts
+
+    # Optional VNC — asked after all main steps
+    step_vnc_optional
+
+    # Apply username to native Termux shell prompt
+    BASHRC="$HOME/.bashrc"
+    grep -q "SETUP_USERNAME_PROMPT" "$BASHRC" 2>/dev/null || \
+        echo "# SETUP_USERNAME_PROMPT\nexport PS1='\[\033[01;32m\]${SETUP_USERNAME}@android\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> "$BASHRC"
+    source "$BASHRC" 2>/dev/null || true
+
+    show_completion
+}
+
+main


### PR DESCRIPTION
## Title

Add unified Android app bridge and advanced Waydroid helper hooks to DroidDesk

## Description

This PR pushes DroidDesk closer to a true Android + Linux desktop workflow instead of treating the phone and the Linux side as two separate worlds.

### What changed

- Added a new Android App Bridge to the setup flow
- Generated `~/android-app-sync.sh` to scan installed Android apps and build desktop launchers for them inside DroidDesk
- Generated `~/install-android-apk.sh` for quick APK handoff to Android's package installer
- Generated `~/start-waydroid.sh` as an advanced helper entry point for compatible environments where Waydroid is installed separately
- Hooked Android app syncing into desktop startup so the menu stays current
- Added desktop shortcuts for Android app refresh and the Waydroid helper
- Updated the README to explain the new mixed Android + Linux workflow, command surface, limits, and contributor credits

### Why this matters

DroidDesk already gives Android phones a real Linux desktop. This update closes one of the biggest usability gaps by making the Android side reachable from inside that desktop instead of forcing users to constantly jump back out to the phone launcher.

That means:

- Linux apps and phone apps now feel like part of the same working environment
- Installed Android apps can be surfaced directly in the DroidDesk menu
- APK installation can be triggered from the Termux side with a single command
- The desktop startup flow now refreshes both Linux-side bridge apps and Android-side bridge apps automatically

On devices with stronger freeform windowing or desktop-style external display behavior, this makes DroidDesk feel much closer to a unified mobile workstation. On standard Android builds, it still removes a lot of friction by letting users launch phone apps from inside the Linux desktop workflow.

### Important implementation note

I intentionally did not add a misleading stock-Termux `apt install waydroid` path. Real Waydroid depends on a compatible Linux base and kernel/container support, so this PR keeps that as an advanced helper path instead of pretending it is universally available on every DroidDesk install.

### Docs / attribution

The README now includes contributor credit for the Android integration push:
- Samin Yeasar
- Instagram: `solez_ai`
- GitHub: `solez-ai`
- X: `Solez_None`
