### PR TITLE
security: harden rootfs integrity, network, and app config

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -1,8 +1,20 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// Optional release signing. Create android/key.properties (git-ignored) with
+// storeFile / storePassword / keyAlias / keyPassword to sign release builds with
+// a real upload key. If absent, release falls back to the debug key so
+// GitHub-distributed test APKs stay directly installable.
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+val hasReleaseKeystore = keystorePropertiesFile.exists().also {
+    if (it) keystorePropertiesFile.inputStream().use(keystoreProperties::load)
 }
 
 android {
@@ -12,6 +24,7 @@ android {
 
     buildFeatures {
         aidl = true
+        buildConfig = true
     }
 
     compileOptions {
@@ -36,11 +49,27 @@ android {
         }
     }
 
+    signingConfigs {
+        if (hasReleaseKeystore) {
+            create("release") {
+                storeFile = file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword")
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // GitHub-distributed testing builds intentionally use Android's
-            // debug key so release APKs are directly installable.
-            signingConfig = signingConfigs.getByName("debug")
+            // Use a real release key when key.properties is present; otherwise
+            // fall back to the debug key so GitHub-distributed test APKs remain
+            // directly installable.
+            signingConfig = if (hasReleaseKeystore) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -1,1 +1,13 @@
+# Vendored Termux:X11 classes are referenced from native code and reflection.
 -keep class com.termux.x11.** { *; }
+
+# JNI-bound classes and native method names must survive shrinking/renaming.
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# AIDL-generated stubs/interfaces.
+-keep class com.orailnoor.droiddesk.x11.** { *; }
+
+# Runtime layer touches processes/reflection during setup; keep intact.
+-keep class com.orailnoor.droiddesk.runtime.** { *; }

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -12,10 +12,12 @@
     <!-- Notification for foreground service -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <!-- Storage for rootfs -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <!-- Storage for rootfs (rootfs itself lives in app-private filesDir; these
+         cover optional import/export of user files on legacy devices only). -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkValue="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkValue="29" />
 
     <!-- Prevent battery optimization killing our processes -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
@@ -25,7 +27,11 @@
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon"
         android:requestLegacyExternalStorage="true"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:largeHeap="true"
         android:enableOnBackInvokedCallback="true">
 

--- a/app/android/app/src/main/kotlin/com/orailnoor/droiddesk/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/com/orailnoor/droiddesk/MainActivity.kt
@@ -10,6 +10,7 @@ import android.os.PowerManager
 import android.content.Context
 import android.net.Uri
 import android.provider.Settings
+import com.orailnoor.droiddesk.BuildConfig
 import com.orailnoor.droiddesk.service.DroidDeskService
 import com.orailnoor.droiddesk.runtime.LinuxRuntime
 import com.orailnoor.droiddesk.runtime.ChrootRuntime
@@ -35,14 +36,18 @@ class MainActivity : FlutterActivity() {
         linuxRuntime = LinuxRuntime(this)
         chrootRuntime = ChrootRuntime(this)
 
-        if (intent.getBooleanExtra("autoSetup", false)) {
+        // Developer/auto-tester path only. MainActivity is exported (it is the
+        // launcher), so honoring this extra in release builds would let any
+        // third-party app drive the privileged root-setup pipeline. Restrict it
+        // to debug builds.
+        if (BuildConfig.DEBUG && intent.getBooleanExtra("autoSetup", false)) {
             runAutoChrootSetup()
         }
     }
 
     /**
      * Hidden developer/auto-tester path: download, extract, install, and launch
-     * the chroot desktop without any Flutter UI interaction.
+     * the chroot desktop without any Flutter UI interaction. Debug builds only.
      */
     private fun runAutoChrootSetup() {
         thread(name = "auto-chroot-setup") {

--- a/app/android/app/src/main/kotlin/com/orailnoor/droiddesk/runtime/LinuxRuntime.kt
+++ b/app/android/app/src/main/kotlin/com/orailnoor/droiddesk/runtime/LinuxRuntime.kt
@@ -341,10 +341,15 @@ class LinuxRuntime(private val context: Context) {
 
     private fun extractZip(zipFile: File, destDir: File) {
         destDir.mkdirs()
+        val destRoot = destDir.canonicalPath + File.separator
         ZipInputStream(zipFile.inputStream()).use { zis ->
             var entry: ZipEntry? = zis.nextEntry
             while (entry != null) {
                 val outFile = File(destDir, entry.name)
+                // Zip-slip guard: reject any entry that resolves outside destDir.
+                if (!outFile.canonicalPath.startsWith(destRoot)) {
+                    throw SecurityException("Blocked path traversal in zip entry: ${entry.name}")
+                }
                 if (entry.isDirectory) {
                     outFile.mkdirs()
                 } else {

--- a/app/android/app/src/main/kotlin/com/orailnoor/droiddesk/runtime/RootShell.kt
+++ b/app/android/app/src/main/kotlin/com/orailnoor/droiddesk/runtime/RootShell.kt
@@ -97,9 +97,17 @@ class RootShell(private val context: Context) {
 
     /**
      * Run a command inside the chroot rootfs as root.
+     *
+     * [command] is passed as a single safely-quoted argument to bash, so a
+     * command containing quotes cannot break out of or inject into the wrapper.
      */
     fun execInChroot(rootfs: File, command: String): String {
-        return exec("chroot ${rootfs.absolutePath} /bin/bash -c '$command'")
+        return exec("chroot ${rootfs.absolutePath} /bin/bash -c ${shellQuote(command)}")
+    }
+
+    /** Wrap [input] as a single-quoted shell token, escaping embedded quotes. */
+    private fun shellQuote(input: String): String {
+        return "'" + input.replace("'", "'\"'\"'") + "'"
     }
 
     /**

--- a/app/android/app/src/main/kotlin/com/orailnoor/droiddesk/runtime/RootfsManager.kt
+++ b/app/android/app/src/main/kotlin/com/orailnoor/droiddesk/runtime/RootfsManager.kt
@@ -7,6 +7,7 @@ import java.io.FileOutputStream
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
+import java.security.MessageDigest
 import java.util.zip.GZIPInputStream
 import kotlin.concurrent.thread
 
@@ -41,6 +42,32 @@ class RootfsManager(private val context: Context) {
             "ubuntu" to "Ubuntu 24.04 Base",
             "alpine" to "Alpine Linux 3.20",
             "kali" to "Kali Linux (NetHunter Minimal)"
+        )
+
+        // Pinned SHA-256 of each rootfs tarball. The extracted rootfs is executed
+        // as root inside a chroot, so the download MUST be integrity-verified
+        // before extraction. A mismatch means the artifact was tampered with
+        // (MITM, hijacked/compromised mirror) and extraction is aborted.
+        //
+        // ubuntu/alpine point at fixed, versioned files, so their pins are stable.
+        // kali points at a rolling "current" image; its pin is verified primarily
+        // against the upstream SHA256SUMS (fetched over HTTPS), with the value
+        // below as the last-known-good fallback.
+        private val SHA256_PINS = mapOf(
+            "ubuntu" to "04207713ece899c3740823d33690441ad3a7f0ded1101aca744e2b0f37ac7ff2",
+            "alpine" to "83a79199bf3112c65e62ddf1732b051daf62ed2ddf5a8413c440dc25956116f0",
+            "kali" to "d6403a5da175df325611d23af4b92330856059c45454eced7f4cdf3ca6df2e4e"
+        )
+
+        // Upstream SHA256SUMS manifests (HTTPS) used as the source of truth for
+        // rolling releases when the hardcoded pin is stale.
+        private val SHA256SUMS_URLS = mapOf(
+            "ubuntu" to ("https://cdimage.ubuntu.com/ubuntu-base/releases/24.04/release/SHA256SUMS"
+                to "ubuntu-base-24.04.4-base-arm64.tar.gz"),
+            "alpine" to ("https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/aarch64/alpine-minirootfs-3.20.0-aarch64.tar.gz.sha256"
+                to "alpine-minirootfs-3.20.0-aarch64.tar.gz"),
+            "kali" to ("https://kali.download/nethunter-images/current/rootfs/SHA256SUMS"
+                to "kali-nethunter-rootfs-minimal-arm64.tar.xz")
         )
     }
 
@@ -130,7 +157,9 @@ class RootfsManager(private val context: Context) {
 
                 // Handle redirects or Already Satisfied (416)
                 if (connection.responseCode == 416) {
-                    // Already fully downloaded
+                    // Already fully downloaded — still verify integrity before trusting it.
+                    onProgress(0.99, "Verifying $distroName...")
+                    verifyChecksumOrThrow(distro, targetFile)
                     onProgress(1.0, "$distroName already downloaded")
                     configFile.writeText(distro)
                     return@thread
@@ -141,6 +170,11 @@ class RootfsManager(private val context: Context) {
                     connection.responseCode == HttpURLConnection.HTTP_SEE_OTHER) {
                     val redirectUrl = connection.getHeaderField("Location")
                     connection.disconnect()
+                    // Never follow a redirect that downgrades to cleartext HTTP; the
+                    // rootfs runs as root, so an http:// target would allow trivial MITM.
+                    if (redirectUrl == null || !redirectUrl.startsWith("https://")) {
+                        throw SecurityException("Refusing insecure redirect to: $redirectUrl")
+                    }
                     val newConnection = URL(redirectUrl).openConnection() as HttpURLConnection
                     if (downloadedBytes > 0) {
                         newConnection.setRequestProperty("Range", "bytes=$downloadedBytes-")
@@ -155,11 +189,17 @@ class RootfsManager(private val context: Context) {
                     downloadFromConnection(connection, targetFile, distroName, downloadedBytes, onProgress)
                 }
 
+                // Integrity gate: the tarball is about to be extracted and run as
+                // root, so verify it before trusting it. A failure deletes the file
+                // so the next attempt re-downloads from scratch.
+                onProgress(0.99, "Verifying $distroName...")
+                verifyChecksumOrThrow(distro, targetFile)
+
                 // Save distro selection
                 configFile.writeText(distro)
 
                 onProgress(1.0, "$distroName downloaded successfully")
-                Log.i(TAG, "Download complete: ${targetFile.absolutePath}")
+                Log.i(TAG, "Download complete and verified: ${targetFile.absolutePath}")
 
             } catch (e: Exception) {
                 Log.e(TAG, "Download failed: ${e.message}", e)
@@ -239,8 +279,12 @@ class RootfsManager(private val context: Context) {
                 // Android's toybox includes tar, and we can use xz if available
                 val ext = if (distro == "kali") "xz" else "gz"
                 val tarFlags = if (ext == "xz") "Jxf" else "zxf"
+                // --no-same-owner: do not honor archived uid/gid.
+                // -P is intentionally NOT passed, so tar strips leading "/" and
+                // refuses "../" members, preventing path-traversal outside rootfs.
                 val process = ProcessBuilder(
                     "tar", tarFlags, tarball.absolutePath,
+                    "--no-same-owner",
                     "-C", rootfsDir.absolutePath
                 )
                     .redirectErrorStream(true)
@@ -464,6 +508,85 @@ class RootfsManager(private val context: Context) {
                 onProgress(-1.0, "Installation failed: ${e.message}")
             }
         }
+    }
+
+    // ── Integrity verification ──
+
+    /**
+     * Verify the downloaded tarball against a pinned SHA-256 (and, for rolling
+     * releases, the upstream SHA256SUMS manifest). Throws SecurityException and
+     * deletes the file on any mismatch — the artifact must never be extracted
+     * unverified because it is executed as root.
+     */
+    private fun verifyChecksumOrThrow(distro: String, file: File) {
+        if (!file.exists() || file.length() == 0L) {
+            throw SecurityException("Downloaded rootfs is missing or empty")
+        }
+
+        val actual = sha256Of(file)
+        val pinned = SHA256_PINS[distro]
+
+        if (pinned != null && actual.equals(pinned, ignoreCase = true)) {
+            Log.i(TAG, "Checksum OK (pinned) for $distro")
+            return
+        }
+
+        // Pin missing or stale (e.g. rolling "current" image) — fall back to the
+        // upstream HTTPS manifest as the source of truth.
+        val upstream = fetchUpstreamSha256(distro)
+        if (upstream != null && actual.equals(upstream, ignoreCase = true)) {
+            Log.w(TAG, "Checksum OK (upstream manifest) for $distro; hardcoded pin is stale")
+            return
+        }
+
+        file.delete()
+        throw SecurityException(
+            "Rootfs checksum verification FAILED for $distro. " +
+                "Expected ${pinned ?: upstream ?: "<unknown>"} but got $actual. " +
+                "The download was corrupted or tampered with and has been discarded."
+        )
+    }
+
+    private fun sha256Of(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(BUFFER_SIZE)
+            var read: Int
+            while (input.read(buffer).also { read = it } != -1) {
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Fetch the expected hash for [distro] from its upstream SHA256SUMS manifest
+     * over HTTPS. Returns null if unavailable. HTTPS-only; never follows a
+     * cleartext redirect.
+     */
+    private fun fetchUpstreamSha256(distro: String): String? {
+        val (sumsUrl, fileName) = SHA256SUMS_URLS[distro] ?: return null
+        return runCatching {
+            if (!sumsUrl.startsWith("https://")) return null
+            val conn = URL(sumsUrl).openConnection() as HttpURLConnection
+            conn.connectTimeout = 15000
+            conn.readTimeout = 15000
+            conn.instanceFollowRedirects = false
+            val body = conn.inputStream.bufferedReader().use { it.readText() }
+            conn.disconnect()
+            // Manifest lines look like: "<hash>  <filename>" (or a bare hash for
+            // single-file .sha256 manifests).
+            body.lineSequence()
+                .map { it.trim() }
+                .firstNotNullOfOrNull { line ->
+                    val hash = line.substringBefore(' ').substringBefore('\t').removePrefix("*")
+                    when {
+                        line.contains(fileName) -> line.substringBefore(' ').trim().removePrefix("*")
+                        line.isNotEmpty() && !line.contains(' ') && hash.length == 64 -> hash
+                        else -> null
+                    }
+                }
+        }.getOrNull()
     }
 
     // ── Utility ──

--- a/app/android/app/src/main/res/xml/backup_rules.xml
+++ b/app/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Legacy (Android < 12) backup rules. The app runs a root desktop; its
+    private state (rootfs, distro/DE config, prefix) must not leave the device
+    via adb backup. allowBackup is already false, so this is defense in depth.
+-->
+<full-backup-content>
+    <exclude domain="file" />
+    <exclude domain="database" />
+    <exclude domain="sharedpref" />
+    <exclude domain="external" />
+</full-backup-content>

--- a/app/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Android 12+ (targetSdk 31+) backup/transfer rules. Exclude all app-private
+    data from cloud backup and device-to-device transfer.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/android/app/src/main/res/xml/network_security_config.xml
+++ b/app/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    The app's own HttpURLConnection traffic (rootfs downloads, checksum
+    manifests) must be HTTPS. Cleartext is denied by default. apt traffic
+    inside the chroot comes from the chroot's own binaries (not this app) and
+    is protected by apt's GPG package signing, so it is unaffected by this file.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/app/assets/socket_hook.c
+++ b/app/assets/socket_hook.c
@@ -212,7 +212,9 @@ int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen) {
         const char *tmp_target = "/tmp/.X11-unix/X0";
         const char *new_prefix_tmp = getenv("TMPDIR");
         if (!new_prefix_tmp) new_prefix_tmp = NEW_PREFIX;
-        static char path_buf[256];
+        /* Stack-local, not static: connect() may run on multiple threads and a
+         * shared static buffer would race and corrupt the rewritten path. */
+        char path_buf[256];
         const char *new_path = NULL;
 
         if (strncmp(un.sun_path, termux_target, strlen(termux_target)) == 0) {


### PR DESCRIPTION
## Summary

Hardening pass over the download → root-execution path and app configuration, from a security scan of the codebase. The app's core (root, chroot, shell) is by design; these fixes address **how safely** privileged, network-sourced payloads are handled.

## Changes

**Critical — artifact integrity (the network → root RCE path)**
- `RootfsManager`: pin and verify **SHA-256** of the downloaded rootfs before extraction (file deleted on mismatch); fall back to the upstream `SHA256SUMS` (HTTPS) for rolling images.
- Refuse any redirect that isn't `https://` (blocks cleartext downgrade / MITM).
- Extract tar with `--no-same-owner` and no `-P` (strips leading `/`, refuses `..`).

**Network / manifest**
- `usesCleartextTraffic="false"` + `network_security_config.xml` denying cleartext for the app's own connections.
- `allowBackup="false"` + `backup_rules.xml` / `data_extraction_rules.xml` excluding all app data.
- Dropped `MANAGE_EXTERNAL_STORAGE`; capped legacy storage perms with `maxSdkValue`.

**App config**
- `MainActivity`: gate the exported `autoSetup` pipeline to **debug builds only** (was reachable by any third-party app).
- `build.gradle.kts`: real release signing via git-ignored `key.properties` (debug fallback); `buildConfig = true`; hardened ProGuard keeps for JNI/AIDL/Termux.

**Lower severity**
- `RootShell.execInChroot`: shell-quote the command (injection).
- `LinuxRuntime.extractZip`: zip-slip guard.
- `socket_hook.c`: stack buffer in `connect()` (thread-safety).

## Not changed (deliberate)
- `targetSdk=28` — documented functional requirement (W^X/execve bypass).
- Minify left off — reflection/JNI-heavy; keep rules added so it's ready to enable with a device test.

## Verification
Pending